### PR TITLE
Release v1.0.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-learning",
-  "version": "0.3.30",
+  "version": "1.0.0",
   "description": "Learn while vibe coding - Spaced repetition learning",
   "author": {
     "name": "jeongjeong-il"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,6 +131,49 @@ record_learning("cache-aside", 2, "correct")
 "Correct! Next review: 3 days"
 ```
 
+## Interview Prep Mode
+
+When user runs `/learn interview`:
+
+1. Call `get_interview_data` to get technical areas and mastery levels
+2. Present topics using the formatted output:
+   ```
+   **[VibeLearning Interview Prep]**
+
+   Technical Areas:
+   • {area} - {implementations} implementations, {mastery}% mastery {← Weak area if isWeak}
+
+   Which area would you like to practice?
+   ```
+
+3. When user selects an area:
+   - Pick a concept from that area's concepts list
+   - Ask a behavioral/technical question:
+     "You implemented {concept}. Walk me through:
+     - Why did you choose this approach?
+     - What tradeoffs did you consider?
+     - What would you do differently at scale?"
+
+4. After user answers:
+   - Acknowledge good points
+   - Suggest improvements for stronger answers
+   - Mention what interviewers look for (the "why", tradeoffs, real-world experience)
+   - Call `record_learning` with the concept and result
+
+### Interview Question Style
+
+Ask questions that test understanding, not just recall:
+- "Walk me through your decision process for..."
+- "What happens if X fails? How would you handle it?"
+- "Compare this to alternative approaches. Why this one?"
+- "How would this change with 10x more traffic?"
+
+### Tone
+
+Be encouraging but constructive. This is practice, not a test.
+- Good: "Strong point about X! To make it even better, mention Y."
+- Avoid: "Wrong. The correct answer is..."
+
 ## Commands
 
 - `/learn` or `/learn status` - Show current mode status
@@ -145,3 +188,4 @@ record_learning("cache-aside", 2, "correct")
 - `/learn report` - Weekly report
 - `/learn unknowns` - Unknown unknowns list
 - `/learn review` - Review due concepts
+- `/learn interview` - Start interview practice

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,33 @@ After user response, call `record_learning`:
 - "Let's strengthen the basics! Found your level: Level 2"
 - NOT "You got it wrong, level decreased"
 
-### 5. Unknown Unknowns
+### 5. Review Chaining (Auto-trigger SM-2 Reviews)
+
+**IMPORTANT**: After recording a learning result, check for due reviews:
+
+1. Call `get_due_reviews` (limit: 1)
+2. If there's a concept due for review:
+   - Ask ONE review question immediately
+   - Format:
+     ```
+     **[VibeLearning Review]**
+     _Review Question (Level X) - {conceptId}_
+     [Your question here]?
+     ```
+3. After user responds, call `record_learning` for the review
+4. Do NOT chain more reviews (max 1 review per learning session)
+
+**Why this matters:**
+- SM-2 spaced repetition only works if reviews actually happen
+- SessionStart hooks can't trigger proactive questions
+- This ensures reviews happen naturally in the learning flow
+
+**Fatigue Management:**
+- Learning question + Review question = max 2 questions per task
+- If user skips review, don't ask another one
+- Respect the 15-minute cooldown for the NEXT task
+
+### 6. Unknown Unknowns
 When you discover related concepts the user might not know:
 - Record with `record_unknown_unknown`
 - Example: While implementing JWT -> record "refresh-token-rotation"
@@ -103,6 +129,7 @@ AFTER task completion:
 
 ## Example Flow
 
+### Basic Learning Flow
 ```
 [Task Completed]
 |
@@ -117,18 +144,50 @@ get_concept_level("cache-aside") -> level: 3 (new concept, starts at 3)
 record_learning("cache-aside", 3, "incorrect")
 |
 "Let's strengthen the basics! Found your level: Level 2. Next review: 1 day"
+```
 
-[Next Session]
+### Review Chaining Flow
+```
+[Task Completed - JWT Authentication]
 |
-get_concept_level("cache-aside") -> level: 2
+should_ask_question -> shouldAsk: true
 |
-"Can you explain how Cache-Aside pattern works?"
+get_concept_level("jwt-auth") -> level: 3
+|
+**[VibeLearning]**
+_Learning Question (Level 3)_
+"What's the difference between JWT and session-based auth?"
+|
+[User Response: Correct]
+|
+record_learning("jwt-auth", 3, "correct")
+"Correct! ..."
+|
+get_due_reviews(limit: 1) -> [{conceptId: "cache-aside", level: 2, daysOverdue: 1}]
+|
+**[VibeLearning Review]**
+_Review Question (Level 2) - cache-aside_
+"Can you explain how the Cache-Aside pattern works?"
 |
 [User Response: Correct]
 |
 record_learning("cache-aside", 2, "correct")
+"Great! Review complete. Next review: 3 days"
 |
-"Correct! Next review: 3 days"
+[Done - No more chaining]
+```
+
+### Skip Handling
+```
+[Learning Question Asked]
+|
+[User: "skip"]
+|
+record_learning("jwt-auth", 3, "skipped")
+|
+get_due_reviews(limit: 1) -> has due review
+|
+[Do NOT ask review question - user already skipped]
 ```
 
 ## Interview Prep Mode

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,7 @@ After user response, call `record_learning`:
 
 **Fatigue Management:**
 - Learning question + Review question = max 2 questions per task
-- If user skips review, don't ask another one
+- If user skips the learning question, don't ask review question
 - Respect the 15-minute cooldown for the NEXT task
 
 ### 6. Unknown Unknowns

--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ npx vibe-learning install opencode
 2. Go to **Marketplaces** tab
 3. Click **+ Add Marketplace**
 4. Enter: `12OneTwo12/vibe-learning`
-5. Click **Browse plugins**
-6. Select **vibe-learning** and click **Install**
+5. Go to **Discover** tab
+6. Select **vibe-learning** and Enter **Install**
 7. Restart Claude Code
 
 **What gets installed:**

--- a/README.md
+++ b/README.md
@@ -286,6 +286,22 @@ npm test
 npm run lint
 ```
 
+## FAQ
+
+### Do I really need a plugin for this?
+
+Honestly, no. Most of VibeLearning's features can be implemented with just prompts or CLAUDE.md instructions. You could set up spaced repetition questions, senior mode discussions, and learning tracking through well-crafted system prompts alone.
+
+However, we built this as a plugin for those who:
+- Don't want to manually configure system prompts for every project
+- Prefer a one-click install over copy-pasting CLAUDE.md instructions
+- Want the few extra features that only MCP/plugins can provide:
+  - **Persistent SQLite database** for tracking progress across sessions
+  - **SM-2 algorithm calculations** with automatic review scheduling
+  - **Cross-project statistics** and reports
+
+If you enjoy configuring things yourself, feel free to grab ideas from our [CLAUDE.md](./CLAUDE.md) and adapt them to your workflow.
+
 ## Architecture
 
 ```

--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ For direct MCP integration or custom implementations:
 | `get_mode` / `set_mode` | Manage learning mode |
 | `save_report` | Save report to markdown file |
 | `save_unknowns` | Save unknowns to markdown file |
+| `get_interview_data` | Get interview prep data with mastery levels |
 
 ## Data Storage
 
@@ -290,7 +291,7 @@ npm run lint
 │  │              MCP Server (Core)                   │   │
 │  │  - SM-2 Algorithm                                │   │
 │  │  - SQLite Database                               │   │
-│  │  - 13 Tools                                      │   │
+│  │  - 14 Tools                                      │   │
 │  └─────────────────────────────────────────────────┘   │
 │                                                          │
 └─────────────────────────────────────────────────────────┘

--- a/README.md
+++ b/README.md
@@ -54,6 +54,18 @@ npx vibe-learning install opencode
 - Hooks: SessionStart, PostToolUse, Stop
 - Command: `/vibe-learning:learn`
 
+**Auto-approve MCP permissions (recommended):**
+
+Claude Code asks for MCP tool permissions every new session. To skip this, add to `~/.claude/settings.json`:
+
+```json
+{
+  "permissions": {
+    "allow": ["mcp__vibe-learning"]
+  }
+}
+```
+
 ### Check Status
 
 ```bash

--- a/commands/learn.md
+++ b/commands/learn.md
@@ -57,15 +57,19 @@ Call: `set_mode` with `focus_area="<area>"`
 
 Call: `get_stats` with `period="month"`
 
-Format results as dashboard.
+Display the response's formattedOutput field if available. Otherwise format as dashboard.
 
 ## `report` - Weekly Report
 
 Call: `get_report_data` with `period="week"`
 
+Display the response's formattedOutput field directly.
+
 ## `report month` - Monthly Report
 
 Call: `get_report_data` with `period="month"`
+
+Display the response's formattedOutput field directly.
 
 ## `report --save` - Save Report
 
@@ -74,6 +78,8 @@ Call: `save_report` with `period="week"`
 ## `unknowns` - Unknown Unknowns
 
 Call: `get_unknown_unknowns` with `period="month", limit=10`
+
+Display the response's formattedOutput field directly.
 
 ## `unknowns --save` - Save Unknowns
 
@@ -87,6 +93,6 @@ Then ask questions for each due concept.
 
 ## `interview` - Interview Mode
 
-Call: `get_stats` with `period="month"`
+Call: `get_interview_data` with `period="month"`
 
-Then conduct interview-style deep questions on learned concepts.
+Display the response's formattedOutput field, then follow the interviewBehavior instructions to conduct interview practice.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vibe-learning",
-  "version": "0.3.30",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vibe-learning",
-      "version": "0.3.30",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-learning",
-  "version": "0.3.33",
+  "version": "1.0.0",
   "description": "Learn while vibe coding - Spaced repetition learning for AI coding agents",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/opencode-plugin/package-lock.json
+++ b/packages/opencode-plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vibe-learning-opencode",
-  "version": "0.2.9",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vibe-learning-opencode",
-      "version": "0.2.9",
+      "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
         "@opencode-ai/plugin": "^1.1.4",

--- a/packages/opencode-plugin/package.json
+++ b/packages/opencode-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-learning-opencode",
-  "version": "0.2.17",
+  "version": "1.0.0",
   "description": "VibeLearning plugin for OpenCode - spaced repetition learning while coding",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/opencode-plugin/src/index.ts
+++ b/packages/opencode-plugin/src/index.ts
@@ -251,15 +251,15 @@ Call mcp__vibe-learning__should_ask_question to check.
 
 **STEP 5: Review Chaining (AFTER learning question is answered)**
 After calling record_learning:
-1. Call mcp__vibe-learning__get_due_reviews with limit=1
-2. If there's a due review AND user didn't skip the learning question:
+1. If the user skipped the learning question, skip the review too.
+2. Otherwise, call mcp__vibe-learning__get_due_reviews with limit=1.
+3. If a due review is found:
    - Format:
      **[VibeLearning Review]**
      _Review Question (Level X) - {conceptId}_
      [Your question here]?
    - After user answers, call mcp__vibe-learning__record_learning for the review
-3. Do NOT chain more reviews (max 1 review per learning session)
-4. If user skipped the learning question, skip the review too`;
+4. Do NOT chain more reviews (max 1 review per learning session)`;
 
 function parseLearnCommand(text: string): string | null {
   const lower = text.toLowerCase().trim();

--- a/packages/opencode-plugin/src/index.ts
+++ b/packages/opencode-plugin/src/index.ts
@@ -145,33 +145,26 @@ const COMMAND_PROMPTS: Record<string, string> = {
 - Cooldown status
 - Consecutive skips`,
 
-  stats: `Execute NOW: Call mcp__vibe-learning__get_stats with period="month", then format as a dashboard showing:
-- Total concepts learned
-- Correct rate percentage
-- Average level
-- Per-concept breakdown`,
+  stats: `Execute NOW: Call mcp__vibe-learning__get_stats with period="month".
+Display the response's formattedOutput field directly if available. Otherwise format as dashboard.`,
 
-  report: `Execute NOW: Call mcp__vibe-learning__get_report_data with period="week", then format as a report with:
-- Summary
-- Weak areas needing reinforcement
-- Strong areas
-- Skipped concepts
-- Growth trends`,
+  report: `Execute NOW: Call mcp__vibe-learning__get_report_data with period="week".
+Display the response's formattedOutput field directly. This contains a pre-formatted report.`,
 
-  "report-month": `Execute NOW: Call mcp__vibe-learning__get_report_data with period="month", then format as monthly report.`,
+  "report-month": `Execute NOW: Call mcp__vibe-learning__get_report_data with period="month".
+Display the response's formattedOutput field directly.`,
 
   "report-save": `Execute NOW: Call mcp__vibe-learning__save_report with period="week". Confirm file saved.`,
 
-  unknowns: `Execute NOW: Call mcp__vibe-learning__get_unknown_unknowns with period="month" and limit=10, then show:
-- Unknown concepts by priority
-- Why each is important
-- Related concepts`,
+  unknowns: `Execute NOW: Call mcp__vibe-learning__get_unknown_unknowns with period="month" and limit=10.
+Display the response's formattedOutput field directly. This contains a pre-formatted list.`,
 
   "unknowns-save": `Execute NOW: Call mcp__vibe-learning__save_unknowns with period="month" and limit=20. Confirm file saved.`,
 
   review: `Execute NOW: Call mcp__vibe-learning__get_due_reviews with limit=5. For each due concept, ask a level-appropriate question and record results.`,
 
-  interview: `Execute NOW: Call mcp__vibe-learning__get_stats with period="month". Then conduct interview-style Level 3-5 questions on the learned concepts.`,
+  interview: `Execute NOW: Call mcp__vibe-learning__get_interview_data with period="month".
+Display the response's formattedOutput field directly, then follow the interviewBehavior instructions to conduct interview practice.`,
 
   pause: `Execute NOW: Call mcp__vibe-learning__set_mode with paused_until set to 1 hour from now (ISO format). Confirm paused.`,
 

--- a/packages/opencode-plugin/src/index.ts
+++ b/packages/opencode-plugin/src/index.ts
@@ -247,7 +247,19 @@ Call mcp__vibe-learning__should_ask_question to check.
     _Learning Question (Level X)_
     [Your question here]?
   - After user answers, call mcp__vibe-learning__record_learning
-- If shouldAsk is false: skip silently (no cooldown message needed)`;
+- If shouldAsk is false: skip silently (no cooldown message needed)
+
+**STEP 5: Review Chaining (AFTER learning question is answered)**
+After calling record_learning:
+1. Call mcp__vibe-learning__get_due_reviews with limit=1
+2. If there's a due review AND user didn't skip the learning question:
+   - Format:
+     **[VibeLearning Review]**
+     _Review Question (Level X) - {conceptId}_
+     [Your question here]?
+   - After user answers, call mcp__vibe-learning__record_learning for the review
+3. Do NOT chain more reviews (max 1 review per learning session)
+4. If user skipped the learning question, skip the review too`;
 
 function parseLearnCommand(text: string): string | null {
   const lower = text.toLowerCase().trim();

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -44,6 +44,7 @@ async function main() {
       const result = fatigueService.shouldAskQuestion();
       console.log(JSON.stringify(result));
       process.exit(result.shouldAsk ? 0 : 1);
+      break;
     }
 
     case 'get-mode': {
@@ -52,6 +53,7 @@ async function main() {
       const mode = modeService.getMode();
       console.log(JSON.stringify(mode));
       process.exit(0);
+      break;
     }
 
     case 'get-random-concept': {
@@ -92,6 +94,7 @@ async function main() {
       // No concepts to review
       console.log(JSON.stringify({ conceptId: null, source: 'none' }));
       process.exit(1);
+      break;
     }
 
     case 'stats': {
@@ -101,6 +104,7 @@ async function main() {
       const stats = statsService.getStats('month');
       console.log(JSON.stringify(stats));
       process.exit(0);
+      break;
     }
 
     default:

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,7 @@ import {
   setModeInputSchema,
   saveReportInputSchema,
   saveUnknownsInputSchema,
+  getInterviewDataInputSchema,
 } from './tools/schemas.js';
 import { VibeLearningError } from './core/errors.js';
 import { closeDatabase } from './db/index.js';
@@ -297,6 +298,23 @@ const TOOLS: Tool[] = [
       required: [],
     },
   },
+  {
+    name: 'get_interview_data',
+    description:
+      'Get interview preparation data with technical areas and mastery levels. Returns topics sorted by mastery (weakest first), recommended topic for practice, and interview behavior instructions for the host LLM.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        period: {
+          type: 'string',
+          enum: ['week', 'month', 'all'],
+          description: 'Time period for interview data',
+          default: 'month',
+        },
+      },
+      required: [],
+    },
+  },
 ];
 
 /**
@@ -423,6 +441,12 @@ function createServer(): Server {
             parsed.limit,
             parsed.filename
           );
+          return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+        }
+
+        case 'get_interview_data': {
+          const parsed = getInterviewDataInputSchema.parse(args ?? {});
+          const result = handlers.getInterviewData(parsed.period as TimePeriod);
           return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
         }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -97,12 +97,13 @@ Execute these steps NOW:
    - After answer, call mcp__vibe-learning__record_learning
 
 4. Review Chaining (AFTER learning question is answered):
-   - Call mcp__vibe-learning__get_due_reviews with limit=1
-   - If there's a due review AND user didn't skip the learning question:
-     **[VibeLearning Review]**
-     _Review Question (Level X) - {conceptId}_
-     [Your question]?
-   - After answer, call mcp__vibe-learning__record_learning for the review
+   - If the user did not skip the learning question:
+     - Call mcp__vibe-learning__get_due_reviews with limit=1.
+     - If a due review is found, ask the review question:
+       **[VibeLearning Review]**
+       _Review Question (Level X) - {conceptId}_
+       [Your question]?
+     - After the answer, call mcp__vibe-learning__record_learning for the review.
    - Do NOT chain more reviews (max 1 per task)
 
 5. If shouldAsk is false: you may stop.`;

--- a/src/main.ts
+++ b/src/main.ts
@@ -96,7 +96,16 @@ Execute these steps NOW:
      [Your question]?
    - After answer, call mcp__vibe-learning__record_learning
 
-4. If shouldAsk is false: you may stop.`;
+4. Review Chaining (AFTER learning question is answered):
+   - Call mcp__vibe-learning__get_due_reviews with limit=1
+   - If there's a due review AND user didn't skip the learning question:
+     **[VibeLearning Review]**
+     _Review Question (Level X) - {conceptId}_
+     [Your question]?
+   - After answer, call mcp__vibe-learning__record_learning for the review
+   - Do NOT chain more reviews (max 1 per task)
+
+5. If shouldAsk is false: you may stop.`;
 
         console.error(instruction);
       }

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -14,3 +14,5 @@ export { ReportService } from './report.service.js';
 export { UnknownUnknownsService } from './unknown-unknowns.service.js';
 
 export { ModeService } from './mode.service.js';
+
+export { InterviewService } from './interview.service.js';

--- a/src/services/interview.service.ts
+++ b/src/services/interview.service.ts
@@ -1,0 +1,227 @@
+/**
+ * Interview Service
+ *
+ * Provides interview preparation data based on learning history.
+ * Helps users practice technical concepts they've implemented.
+ */
+
+import type {
+  TimePeriod,
+  GetInterviewDataResponse,
+  InterviewTopicResponse,
+} from '../types/index.js';
+import {
+  ConceptProgressRepository,
+  LearningRecordRepository,
+} from '../db/index.js';
+import { calculateRate, average, groupBy } from '../core/utils.js';
+
+/**
+ * Interview behavior instructions for host LLM
+ */
+const INTERVIEW_BEHAVIOR = `You are conducting a technical interview practice session.
+
+## How to Use Interview Data
+
+The get_interview_data tool returns:
+- topics: Areas the user has practiced, sorted by mastery (weakest first)
+- recommendedTopic: Suggested area to practice (usually the weakest)
+- Each topic includes: implementations count, mastery %, concepts list
+
+## Interview Flow
+
+1. **Present Topics**: Show available areas with mastery levels
+   Format:
+   "**[VibeLearning Interview Prep]**
+
+   Technical Areas:
+   • {area1} - {implementations} implementations, {mastery}% mastery
+   • {area2} - {implementations} implementations, {mastery}% mastery {← Weak area if isWeak}
+
+   Which area would you like to practice?"
+
+2. **Generate Question**: Based on user's selection:
+   - Pick a concept from that area's concepts list
+   - Ask a behavioral/technical question like:
+     "You implemented {concept}. Walk me through:
+     - Why did you choose this approach?
+     - What tradeoffs did you consider?
+     - What would you do differently at scale?"
+
+3. **Evaluate & Coach**: After user answers:
+   - Acknowledge good points
+   - Suggest improvements for stronger answers
+   - Mention what interviewers look for (the "why", tradeoffs, real-world experience)
+
+4. **Record Learning**: Call record_learning with the concept and result
+
+## Question Style
+
+Ask questions that test understanding, not just recall:
+- "Walk me through your decision process for..."
+- "What happens if X fails? How would you handle it?"
+- "Compare this to alternative approaches. Why this one?"
+- "How would this change with 10x more traffic?"
+
+## Tone
+
+Be encouraging but constructive. This is practice, not a test.
+- Good: "Strong point about X! To make it even better, mention Y."
+- Avoid: "Wrong. The correct answer is..."`;
+
+/**
+ * Service for interview preparation features
+ */
+export class InterviewService {
+  private readonly progressRepo: ConceptProgressRepository;
+  private readonly recordRepo: LearningRecordRepository;
+
+  constructor(
+    progressRepo?: ConceptProgressRepository,
+    recordRepo?: LearningRecordRepository
+  ) {
+    this.progressRepo = progressRepo ?? new ConceptProgressRepository();
+    this.recordRepo = recordRepo ?? new LearningRecordRepository();
+  }
+
+  /**
+   * Gets interview preparation data with topics and mastery levels
+   */
+  getInterviewData(period: TimePeriod = 'month'): GetInterviewDataResponse {
+    const aggregates = this.recordRepo.getAggregateStatsByPeriod(period);
+
+    if (aggregates.length === 0) {
+      return {
+        topics: [],
+        recommendedTopic: null,
+        totalConcepts: 0,
+        formattedOutput: this.formatNoDataOutput(),
+        interviewBehavior: INTERVIEW_BEHAVIOR,
+      };
+    }
+
+    // Group concepts by area
+    const grouped = groupBy(aggregates, (a) => this.extractArea(a.conceptId));
+
+    // Build topic data
+    const topics: InterviewTopicResponse[] = [];
+
+    for (const [area, concepts] of Object.entries(grouped)) {
+      const totalAttempts = concepts.reduce((sum, c) => sum + c.totalAttempts, 0);
+      const totalCorrect = concepts.reduce((sum, c) => sum + c.correctCount, 0);
+      const totalSkipped = concepts.reduce((sum, c) => sum + c.skippedCount, 0);
+
+      const correctRate = calculateRate(totalCorrect, totalAttempts - totalSkipped);
+
+      const levels = concepts.map((c) => {
+        const progress = this.progressRepo.findById(c.conceptId);
+        return progress?.currentLevel ?? 1;
+      });
+      const avgLevel = average(levels);
+
+      // Mastery = (correctRate * 0.6 + normalizedLevel * 0.4) * 100
+      // normalizedLevel = avgLevel / 5
+      const mastery = Math.round((correctRate * 0.6 + (avgLevel / 5) * 0.4) * 100);
+
+      // Area is weak if mastery < 60% or avgLevel < 2.5
+      const isWeak = mastery < 60 || avgLevel < 2.5;
+
+      topics.push({
+        area,
+        implementations: totalAttempts,
+        mastery,
+        isWeak,
+        concepts: concepts.map((c) => c.conceptId),
+        avgLevel: Number(avgLevel.toFixed(1)),
+        correctRate: Number(correctRate.toFixed(2)),
+      });
+    }
+
+    // Sort by mastery (weakest first for recommendations)
+    topics.sort((a, b) => a.mastery - b.mastery);
+
+    // Recommend the weakest area with at least 2 implementations
+    const recommendedTopic = topics.find((t) => t.implementations >= 2)?.area ?? null;
+
+    const result: GetInterviewDataResponse = {
+      topics,
+      recommendedTopic,
+      totalConcepts: aggregates.length,
+      formattedOutput: '',
+      interviewBehavior: INTERVIEW_BEHAVIOR,
+    };
+
+    return {
+      ...result,
+      formattedOutput: this.formatOutput(result),
+    };
+  }
+
+  /**
+   * Gets weak topics for focused practice
+   */
+  getWeakTopics(limit = 3): readonly InterviewTopicResponse[] {
+    const data = this.getInterviewData('month');
+    return data.topics.filter((t) => t.isWeak).slice(0, limit);
+  }
+
+  /**
+   * Gets strong topics (for confidence building)
+   */
+  getStrongTopics(limit = 3): readonly InterviewTopicResponse[] {
+    const data = this.getInterviewData('month');
+    return [...data.topics]
+      .filter((t) => !t.isWeak)
+      .sort((a, b) => b.mastery - a.mastery)
+      .slice(0, limit);
+  }
+
+  /**
+   * Extracts area from concept ID
+   */
+  private extractArea(conceptId: string): string {
+    const parts = conceptId.split(/[-_]/);
+    return parts[0] ?? 'general';
+  }
+
+  /**
+   * Formats output for display
+   */
+  private formatOutput(data: Omit<GetInterviewDataResponse, 'formattedOutput'>): string {
+    const lines: string[] = [];
+
+    lines.push('**[VibeLearning Interview Prep]**');
+    lines.push('');
+    lines.push('Technical Areas:');
+
+    for (const topic of data.topics) {
+      const weakMarker = topic.isWeak ? ' ← Weak area' : '';
+      lines.push(`• ${topic.area} - ${topic.implementations} implementations, ${topic.mastery}% mastery${weakMarker}`);
+    }
+
+    lines.push('');
+
+    if (data.recommendedTopic) {
+      lines.push(`💡 Recommended: Practice **${data.recommendedTopic}** to strengthen your weak areas.`);
+    }
+
+    lines.push('');
+    lines.push('Which area would you like to practice?');
+
+    return lines.join('\n');
+  }
+
+  /**
+   * Formats output when no data available
+   */
+  private formatNoDataOutput(): string {
+    return `**[VibeLearning Interview Prep]**
+
+No learning data yet. Start by completing some coding tasks and answering learning questions.
+
+Once you have practiced a few concepts, you can use interview prep to:
+• Review areas you've worked on
+• Practice explaining your implementation decisions
+• Prepare for technical interviews`;
+  }
+}

--- a/src/tools/handlers.ts
+++ b/src/tools/handlers.ts
@@ -24,6 +24,7 @@ import type {
   MarkExploredResponse,
   SaveReportResponse,
   SaveUnknownsResponse,
+  GetInterviewDataResponse,
 } from '../types/index.js';
 import {
   FatigueService,
@@ -32,6 +33,7 @@ import {
   ReportService,
   UnknownUnknownsService,
   ModeService,
+  InterviewService,
 } from '../services/index.js';
 import { VibeLearningError } from '../core/errors.js';
 
@@ -45,6 +47,7 @@ export class ToolHandlers {
   private readonly reportService: ReportService;
   private readonly unknownsService: UnknownUnknownsService;
   private readonly modeService: ModeService;
+  private readonly interviewService: InterviewService;
 
   constructor() {
     this.fatigueService = new FatigueService();
@@ -53,6 +56,7 @@ export class ToolHandlers {
     this.reportService = new ReportService();
     this.unknownsService = new UnknownUnknownsService();
     this.modeService = new ModeService();
+    this.interviewService = new InterviewService();
   }
 
   /**
@@ -299,6 +303,20 @@ export class ToolHandlers {
         period: report.period,
         message: `Report saved to ${filePath}`,
       };
+    } catch (error) {
+      if (error instanceof VibeLearningError) {
+        throw error;
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * get_interview_data - Get interview preparation data
+   */
+  getInterviewData(period: TimePeriod = 'month'): GetInterviewDataResponse {
+    try {
+      return this.interviewService.getInterviewData(period);
     } catch (error) {
       if (error instanceof VibeLearningError) {
         throw error;

--- a/src/tools/schemas.ts
+++ b/src/tools/schemas.ts
@@ -119,6 +119,13 @@ export const saveUnknownsInputSchema = z.object({
 });
 
 /**
+ * Schema for get_interview_data input
+ */
+export const getInterviewDataInputSchema = z.object({
+  period: timePeriodSchema.default('month').describe('Time period for interview data'),
+});
+
+/**
  * Type exports from schemas
  */
 export type GetConceptLevelInput = z.infer<typeof getConceptLevelInputSchema>;
@@ -132,3 +139,4 @@ export type GetDueReviewsInput = z.infer<typeof getDueReviewsInputSchema>;
 export type SetModeInput = z.infer<typeof setModeInputSchema>;
 export type SaveReportInput = z.infer<typeof saveReportInputSchema>;
 export type SaveUnknownsInput = z.infer<typeof saveUnknownsInputSchema>;
+export type GetInterviewDataInput = z.infer<typeof getInterviewDataInputSchema>;

--- a/src/types/domain.ts
+++ b/src/types/domain.ts
@@ -198,16 +198,3 @@ export interface SeniorModeRound {
   readonly maxRounds: number;
   readonly passed: boolean;
 }
-
-/**
- * Interview topic with mastery data
- */
-export interface InterviewTopic {
-  readonly area: string;
-  readonly implementations: number;
-  readonly mastery: number; // 0-100
-  readonly isWeak: boolean;
-  readonly concepts: readonly string[];
-  readonly avgLevel: number;
-  readonly correctRate: number;
-}

--- a/src/types/domain.ts
+++ b/src/types/domain.ts
@@ -198,3 +198,16 @@ export interface SeniorModeRound {
   readonly maxRounds: number;
   readonly passed: boolean;
 }
+
+/**
+ * Interview topic with mastery data
+ */
+export interface InterviewTopic {
+  readonly area: string;
+  readonly implementations: number;
+  readonly mastery: number; // 0-100
+  readonly isWeak: boolean;
+  readonly concepts: readonly string[];
+  readonly avgLevel: number;
+  readonly correctRate: number;
+}

--- a/src/types/responses.ts
+++ b/src/types/responses.ts
@@ -223,6 +223,30 @@ export interface SaveUnknownsResponse {
 }
 
 /**
+ * Response from get_interview_data tool
+ */
+export interface GetInterviewDataResponse {
+  readonly topics: readonly InterviewTopicResponse[];
+  readonly recommendedTopic: string | null;
+  readonly totalConcepts: number;
+  readonly formattedOutput: string;
+  readonly interviewBehavior: string;
+}
+
+/**
+ * Interview topic in response format
+ */
+export interface InterviewTopicResponse {
+  readonly area: string;
+  readonly implementations: number;
+  readonly mastery: number;
+  readonly isWeak: boolean;
+  readonly concepts: readonly string[];
+  readonly avgLevel: number;
+  readonly correctRate: number;
+}
+
+/**
  * Error response structure
  */
 export interface ErrorResponse {

--- a/tests/services/interview.service.test.ts
+++ b/tests/services/interview.service.test.ts
@@ -1,0 +1,418 @@
+/**
+ * Interview Service Tests
+ *
+ * Uses repositories directly to set up predictable test data,
+ * avoiding dependency on LearningService's SM-2 side effects.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { InterviewService } from '../../src/services/interview.service.js';
+import {
+  ConceptProgressRepository,
+  LearningRecordRepository,
+  resetDatabase,
+  getDatabaseConnection,
+} from '../../src/db/index.js';
+import type { ConceptLevel, LearningResult } from '../../src/types/index.js';
+
+const TEST_DB_DIR = path.join(os.tmpdir(), 'vibe-learning-interview-test-' + Date.now());
+
+describe('InterviewService', () => {
+  let interviewService: InterviewService;
+  let progressRepo: ConceptProgressRepository;
+  let recordRepo: LearningRecordRepository;
+
+  // Helper to create a concept with specific level
+  function createConcept(conceptId: string, level: ConceptLevel = 3): void {
+    progressRepo.getOrCreate(conceptId);
+    if (level !== 3) {
+      progressRepo.update(conceptId, { currentLevel: level });
+    }
+  }
+
+  // Helper to create a learning record directly
+  function createRecord(conceptId: string, level: ConceptLevel, result: LearningResult): void {
+    recordRepo.create({ conceptId, level, result });
+  }
+
+  beforeEach(() => {
+    if (fs.existsSync(TEST_DB_DIR)) {
+      fs.rmSync(TEST_DB_DIR, { recursive: true, force: true });
+    }
+    fs.mkdirSync(TEST_DB_DIR, { recursive: true });
+    getDatabaseConnection({ dbDir: TEST_DB_DIR });
+
+    progressRepo = new ConceptProgressRepository();
+    recordRepo = new LearningRecordRepository();
+    interviewService = new InterviewService(progressRepo, recordRepo);
+  });
+
+  afterEach(() => {
+    resetDatabase();
+    if (fs.existsSync(TEST_DB_DIR)) {
+      fs.rmSync(TEST_DB_DIR, { recursive: true, force: true });
+    }
+  });
+
+  describe('getInterviewData', () => {
+    it('should return empty data when no learning records', () => {
+      const data = interviewService.getInterviewData('month');
+
+      expect(data.topics).toHaveLength(0);
+      expect(data.recommendedTopic).toBeNull();
+      expect(data.totalConcepts).toBe(0);
+    });
+
+    it('should include interviewBehavior instructions', () => {
+      const data = interviewService.getInterviewData('month');
+
+      expect(data.interviewBehavior).toBeDefined();
+      expect(data.interviewBehavior).toContain('technical interview');
+    });
+
+    it('should include formattedOutput', () => {
+      const data = interviewService.getInterviewData('month');
+
+      expect(data.formattedOutput).toBeDefined();
+      expect(typeof data.formattedOutput).toBe('string');
+    });
+
+    it('should format no data output when empty', () => {
+      const data = interviewService.getInterviewData('month');
+
+      expect(data.formattedOutput).toContain('No learning data yet');
+    });
+
+    it('should group concepts by area prefix', () => {
+      // Set up: 2 cache concepts, 1 auth concept
+      createConcept('cache-aside', 3);
+      createConcept('cache-invalidation', 3);
+      createConcept('auth-jwt', 3);
+      createRecord('cache-aside', 3, 'correct');
+      createRecord('cache-invalidation', 3, 'correct');
+      createRecord('auth-jwt', 3, 'correct');
+
+      const data = interviewService.getInterviewData('month');
+
+      expect(data.topics).toHaveLength(2);
+      const cacheArea = data.topics.find(t => t.area === 'cache');
+      const authArea = data.topics.find(t => t.area === 'auth');
+      expect(cacheArea?.concepts).toHaveLength(2);
+      expect(authArea?.concepts).toHaveLength(1);
+    });
+
+    it('should calculate mastery based on correctRate and level', () => {
+      // Set up: concept at level 3, 100% correct rate
+      createConcept('test-concept', 3);
+      createRecord('test-concept', 3, 'correct');
+
+      const data = interviewService.getInterviewData('month');
+      const topic = data.topics[0];
+
+      // mastery = (correctRate * 0.6 + normalizedLevel * 0.4) * 100
+      // correctRate = 1.0, level = 3, normalizedLevel = 3/5 = 0.6
+      // mastery = (1.0 * 0.6 + 0.6 * 0.4) * 100 = 84
+      expect(topic?.mastery).toBe(84);
+      expect(topic?.correctRate).toBe(1);
+      expect(topic?.avgLevel).toBe(3);
+    });
+
+    it('should calculate mastery with mixed results', () => {
+      // Set up: concept at level 2, 50% correct rate
+      createConcept('mixed-concept', 2);
+      createRecord('mixed-concept', 2, 'correct');
+      createRecord('mixed-concept', 2, 'incorrect');
+
+      const data = interviewService.getInterviewData('month');
+      const topic = data.topics[0];
+
+      // correctRate = 0.5, level = 2, normalizedLevel = 2/5 = 0.4
+      // mastery = (0.5 * 0.6 + 0.4 * 0.4) * 100 = (0.3 + 0.16) * 100 = 46
+      expect(topic?.mastery).toBe(46);
+      expect(topic?.correctRate).toBe(0.5);
+      expect(topic?.avgLevel).toBe(2);
+    });
+
+    it('should mark area as weak when mastery < 60%', () => {
+      // Set up: concept at level 1, 0% correct rate -> mastery = 8%
+      createConcept('weak-concept', 1);
+      createRecord('weak-concept', 1, 'incorrect');
+
+      const data = interviewService.getInterviewData('month');
+      const topic = data.topics[0];
+
+      expect(topic?.isWeak).toBe(true);
+      expect(topic?.mastery).toBeLessThan(60);
+    });
+
+    it('should mark area as weak when avgLevel < 2.5', () => {
+      // Set up: concept at level 2, 100% correct rate
+      // mastery = (1.0 * 0.6 + 0.4 * 0.4) * 100 = 76 (not weak by mastery)
+      // but avgLevel = 2 < 2.5, so should be weak
+      createConcept('low-level-concept', 2);
+      createRecord('low-level-concept', 2, 'correct');
+
+      const data = interviewService.getInterviewData('month');
+      const topic = data.topics[0];
+
+      expect(topic?.avgLevel).toBe(2);
+      expect(topic?.isWeak).toBe(true);
+    });
+
+    it('should not mark area as weak when mastery >= 60% and avgLevel >= 2.5', () => {
+      // Set up: concept at level 4, 100% correct rate
+      // mastery = (1.0 * 0.6 + 0.8 * 0.4) * 100 = 92
+      createConcept('strong-concept', 4);
+      createRecord('strong-concept', 4, 'correct');
+
+      const data = interviewService.getInterviewData('month');
+      const topic = data.topics[0];
+
+      expect(topic?.mastery).toBe(92);
+      expect(topic?.avgLevel).toBe(4);
+      expect(topic?.isWeak).toBe(false);
+    });
+
+    it('should sort topics by mastery (weakest first)', () => {
+      // Set up: strong area (level 5, 100%) and weak area (level 1, 0%)
+      createConcept('strong-one', 5);
+      createRecord('strong-one', 5, 'correct');
+
+      createConcept('weak-one', 1);
+      createRecord('weak-one', 1, 'incorrect');
+
+      const data = interviewService.getInterviewData('month');
+
+      expect(data.topics[0]?.area).toBe('weak');
+      expect(data.topics[1]?.area).toBe('strong');
+      expect(data.topics[0]!.mastery).toBeLessThan(data.topics[1]!.mastery);
+    });
+
+    it('should recommend topic with at least 2 implementations', () => {
+      // Area with 1 implementation (not recommended)
+      createConcept('single-concept', 3);
+      createRecord('single-concept', 3, 'correct');
+
+      // Area with 2 implementations (recommended)
+      createConcept('multi-one', 2);
+      createConcept('multi-two', 2);
+      createRecord('multi-one', 2, 'incorrect');
+      createRecord('multi-two', 2, 'incorrect');
+
+      const data = interviewService.getInterviewData('month');
+
+      // multi area has 2 implementations and is weaker
+      expect(data.recommendedTopic).toBe('multi');
+    });
+
+    it('should return null recommendedTopic when no area has 2+ implementations', () => {
+      createConcept('area1-concept', 3);
+      createConcept('area2-concept', 3);
+      createRecord('area1-concept', 3, 'correct');
+      createRecord('area2-concept', 3, 'correct');
+
+      const data = interviewService.getInterviewData('month');
+
+      expect(data.recommendedTopic).toBeNull();
+    });
+
+    it('should count total concepts correctly', () => {
+      createConcept('concept-1', 3);
+      createConcept('concept-2', 3);
+      createConcept('concept-3', 3);
+      createRecord('concept-1', 3, 'correct');
+      createRecord('concept-2', 3, 'correct');
+      createRecord('concept-3', 3, 'correct');
+
+      const data = interviewService.getInterviewData('month');
+
+      expect(data.totalConcepts).toBe(3);
+    });
+
+    it('should respect period parameter', () => {
+      createConcept('recent-concept', 3);
+      createRecord('recent-concept', 3, 'correct');
+
+      const weekData = interviewService.getInterviewData('week');
+      const monthData = interviewService.getInterviewData('month');
+      const allData = interviewService.getInterviewData('all');
+
+      expect(weekData.totalConcepts).toBe(1);
+      expect(monthData.totalConcepts).toBe(1);
+      expect(allData.totalConcepts).toBe(1);
+    });
+
+    it('should include formatted output with topics', () => {
+      createConcept('test-concept', 3);
+      createRecord('test-concept', 3, 'correct');
+
+      const data = interviewService.getInterviewData('month');
+
+      expect(data.formattedOutput).toContain('VibeLearning Interview Prep');
+      expect(data.formattedOutput).toContain('Technical Areas');
+      expect(data.formattedOutput).toContain('test');
+    });
+
+    it('should exclude skipped attempts from correctRate calculation', () => {
+      createConcept('skip-test', 3);
+      createRecord('skip-test', 3, 'correct');
+      createRecord('skip-test', 3, 'skipped');
+      createRecord('skip-test', 3, 'skipped');
+
+      const data = interviewService.getInterviewData('month');
+      const topic = data.topics[0];
+
+      // 1 correct out of 1 non-skipped = 100%
+      expect(topic?.correctRate).toBe(1);
+    });
+
+    it('should calculate implementations as total attempts', () => {
+      createConcept('impl-test', 3);
+      createRecord('impl-test', 3, 'correct');
+      createRecord('impl-test', 3, 'correct');
+      createRecord('impl-test', 3, 'incorrect');
+
+      const data = interviewService.getInterviewData('month');
+      const topic = data.topics[0];
+
+      expect(topic?.implementations).toBe(3);
+    });
+  });
+
+  describe('getWeakTopics', () => {
+    it('should return only weak topics', () => {
+      // Create weak area (level 1)
+      createConcept('weak-concept', 1);
+      createRecord('weak-concept', 1, 'incorrect');
+
+      // Create strong area (level 5, 100%)
+      createConcept('strong-concept', 5);
+      createRecord('strong-concept', 5, 'correct');
+
+      const weakTopics = interviewService.getWeakTopics();
+
+      expect(weakTopics.length).toBe(1);
+      expect(weakTopics[0]?.area).toBe('weak');
+      expect(weakTopics.every(t => t.isWeak)).toBe(true);
+    });
+
+    it('should respect limit parameter', () => {
+      // Create 5 weak areas
+      for (let i = 0; i < 5; i++) {
+        const conceptId = `weak${i}-concept`;
+        createConcept(conceptId, 1);
+        createRecord(conceptId, 1, 'incorrect');
+      }
+
+      const weakTopics = interviewService.getWeakTopics(2);
+
+      expect(weakTopics.length).toBe(2);
+    });
+
+    it('should return empty array when no weak topics', () => {
+      // Create only strong area
+      createConcept('strong-concept', 5);
+      createRecord('strong-concept', 5, 'correct');
+
+      const weakTopics = interviewService.getWeakTopics();
+
+      expect(weakTopics).toHaveLength(0);
+    });
+  });
+
+  describe('getStrongTopics', () => {
+    it('should return only strong topics (not weak)', () => {
+      // Create strong area (level 4, 100% correct)
+      createConcept('strong-concept', 4);
+      createRecord('strong-concept', 4, 'correct');
+
+      // Create weak area (level 1)
+      createConcept('weak-concept', 1);
+      createRecord('weak-concept', 1, 'incorrect');
+
+      const strongTopics = interviewService.getStrongTopics();
+
+      expect(strongTopics.length).toBe(1);
+      expect(strongTopics[0]?.area).toBe('strong');
+      expect(strongTopics.every(t => !t.isWeak)).toBe(true);
+    });
+
+    it('should sort by mastery descending', () => {
+      // Higher mastery area (level 5)
+      createConcept('higher-concept', 5);
+      createRecord('higher-concept', 5, 'correct');
+
+      // Lower mastery area (level 3)
+      createConcept('lower-concept', 3);
+      createRecord('lower-concept', 3, 'correct');
+
+      const strongTopics = interviewService.getStrongTopics();
+
+      if (strongTopics.length >= 2) {
+        expect(strongTopics[0]!.mastery).toBeGreaterThanOrEqual(strongTopics[1]!.mastery);
+      }
+    });
+
+    it('should respect limit parameter', () => {
+      // Create 5 strong areas
+      for (let i = 0; i < 5; i++) {
+        const conceptId = `strong${i}-concept`;
+        createConcept(conceptId, 5);
+        createRecord(conceptId, 5, 'correct');
+      }
+
+      const strongTopics = interviewService.getStrongTopics(2);
+
+      expect(strongTopics.length).toBe(2);
+    });
+  });
+
+  describe('area extraction', () => {
+    it('should extract area from hyphenated concept ID', () => {
+      createConcept('cache-aside-pattern', 3);
+      createRecord('cache-aside-pattern', 3, 'correct');
+
+      const data = interviewService.getInterviewData('month');
+
+      expect(data.topics[0]?.area).toBe('cache');
+    });
+
+    it('should extract area from underscored concept ID', () => {
+      createConcept('auth_jwt_token', 3);
+      createRecord('auth_jwt_token', 3, 'correct');
+
+      const data = interviewService.getInterviewData('month');
+
+      expect(data.topics[0]?.area).toBe('auth');
+    });
+
+    it('should use first part for single-word concept ID', () => {
+      createConcept('singleton', 3);
+      createRecord('singleton', 3, 'correct');
+
+      const data = interviewService.getInterviewData('month');
+
+      // Single word becomes the area itself
+      expect(data.topics[0]?.area).toBe('singleton');
+    });
+  });
+
+  describe('average level calculation across multiple concepts', () => {
+    it('should calculate avgLevel as average of all concepts in area', () => {
+      // Two concepts in same area with different levels
+      createConcept('avg-one', 2);
+      createConcept('avg-two', 4);
+      createRecord('avg-one', 2, 'correct');
+      createRecord('avg-two', 4, 'correct');
+
+      const data = interviewService.getInterviewData('month');
+      const topic = data.topics[0];
+
+      // avgLevel = (2 + 4) / 2 = 3
+      expect(topic?.avgLevel).toBe(3);
+    });
+  });
+});


### PR DESCRIPTION
  ### 작업 내용
  VibeLearning 1.0.0 정식 릴리즈

  ---

  ### 관련 이슈
  Closes #51

  ---

  ### 작업 사항

  #### 핵심 기능 (기획서 Phase 0-3 완료)
  - **SM-2 간격 반복 알고리즘** - Anki와 동일한 검증된 알고리즘
  - **5단계 레벨 시스템** - Recognition → Understanding → Comparison → Edge Cases → Architecture
  - **피로도 관리** - 15분 쿨다운, 연속 스킵 시 자동 일시정지
  - **Unknown Unknowns 추적** - 모르는 것을 모르는 개념 발견 및 시각화
  - **Senior 모드** - 구현 전 시니어 개발자처럼 개념 질문
  - **After 모드** - 작업 완료 후 학습 질문
  - **Interview 모드** - 면접 준비 연습
  - **Review Chaining** - 학습 질문 후 SM-2 리뷰 자동 연결

  #### 플랫폼 지원
  - **Claude Code** - 플러그인 마켓플레이스 배포 (MCP + Hooks)
  - **OpenCode** - npm 플러그인 (vibe-learning-opencode)
  - **기타** - MCP 서버로 수동 연동 가능

  #### 명령어
  - `/learn` - 상태 확인
  - `/learn on/off` - 전체 학습 모드 토글
  - `/learn senior/after` - 개별 모드 토글
  - `/learn stats` - 통계 대시보드
  - `/learn report [month] [--save]` - 학습 리포트
  - `/learn unknowns [--save]` - Unknown Unknowns 대시보드
  - `/learn review` - 복습 필요 개념 리뷰
  - `/learn interview` - 면접 연습 모드
  - `/learn pause` - 1시간 일시정지

  ---

  ### 테스트
  - [x] 로컬 테스트 완료
  - [x] 단위 테스트 작성/통과 (251 tests)
  - [x] 빌드 성공
  - [x] 린트 통과

  ---

  ### 스크린샷 (UI 변경 시)
  N/A

  ---

  ### 참고 사항

  **버전 변경:**
  | 패키지 | 이전 | 이후 |
  |--------|------|------|
  | vibe-learning | 0.3.33 | 1.0.0 |
  | vibe-learning-opencode | 0.2.17 | 1.0.0 |
  | claude-plugin | 0.3.30 | 1.0.0 |

  **기획서 로드맵 완료 상태:**
  - ✅ Phase 0: 개념 증명
  - ✅ Phase 1: MVP
  - ✅ Phase 2: 학습 루프 완성
  - ✅ Phase 3: 완성

  ---

  ### 체크리스트
  - [x] Git Convention 준수
  - [x] 코드 리뷰 준비 완료
  - [x] Breaking Change 여부 확인 (없음)